### PR TITLE
Corrige junção de colunas com tipos incompatíveis

### DIFF
--- a/R/analyzer_disciplina.R
+++ b/R/analyzer_disciplina.R
@@ -96,6 +96,8 @@ get_parlamentares_info <- function() {
     group_by(id_entidade) %>% 
     mutate(ultima_legislatura = max(legislatura)) %>% 
     filter(is_parlamentar == 1, legislatura == ultima_legislatura) %>% 
+    mutate(id_entidade_parlametria = as.numeric(id_entidade_parlametria),
+           id_entidade = as.numeric(id_entidade)) %>% 
     select(id_entidade, id_entidade_parlametria, casa, nome, uf, partido_atual = partido)
   
   return(parlamentares_info)


### PR DESCRIPTION
## Mudanças
- Converte tipos das colunas id_entidade_parlametria e id_entidade
- Evita o erro:
![image](https://user-images.githubusercontent.com/10724115/112041404-207c4d00-8b25-11eb-8cdd-6d0c05fad4f8.png)
